### PR TITLE
Implement CICD for DockerHub and GitHub Docker Image Repositories

### DIFF
--- a/.github/workflows/auto-update-from-base-docker.yml
+++ b/.github/workflows/auto-update-from-base-docker.yml
@@ -1,0 +1,56 @@
+name: Docker Base Auto Update CI
+
+on:
+  schedule:
+  - cron: "23 13 3 * *"
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_PLATFORMS: linux/amd64,linux/armhf,linux/arm64
+
+
+    steps:
+    - 
+      name: Docker Image Update Checker
+      id: baseupdatecheck
+      uses: lucacome/docker-image-update-checker@v1
+      with:
+        base-image: library/ubuntu:latest
+        image: dievus/msToolSet-Docker:latest
+    -
+        name: Checkout
+        uses: actions/checkout@v3
+        if: steps.check.outputs.needs-updating == 'true'
+    -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        if: steps.check.outputs.needs-updating == 'true'
+    -
+        name: setup docker buildx
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+        if: steps.check.outputs.needs-updating == 'true'
+    -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+        if: steps.check.outputs.needs-updating == 'true'
+    - 
+      name: Build the Docker image
+      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && docker buildx build --platform linux/amd64,linux/armhf,linux/arm64 -t dievus/msToolSet-Docker:latest --progress=plain --push .
+    -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: dievus/msToolSet-Docker:latest
+        if: steps.check.outputs.needs-updating == 'true'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,53 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_PLATFORMS: linux/amd64,linux/armhf,linux/arm64
+
+    steps:
+    -
+        name: Checkout
+        uses: actions/checkout@v3
+    -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+    -
+        name: setup docker buildx
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+    -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+    - 
+      name: Build the Docker image
+      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && docker buildx build --platform linux/amd64,linux/armhf,linux/arm64 -t dievus/msToolSet-Docker:latest --progress=plain --push .
+    -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: dievus/msToolSet-Docker:latest
+          
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT_TOKEN }}
+
+    - name: Build the dievus/msToolSet-Docker:latest Docker image for Github Registry
+      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && docker buildx build --platform linux/amd64,linux/armhf,linux/arm64 -t ghcr.io/dievus/msToolSet-Docker:latest --progress=plain --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu as baseline
 
 LABEL maintainer="themayor" github="https://www.github.com/dievus"
+LABEL org.opencontainers.image.source="https://github.com/dievus/msToolSet-Docker"
+LABEL org.opencontainers.image.description="Dockerized version of my most used tools."
+LABEL org.opencontainers.image.authors="dievus"
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata gnupg2 wget apt-utils python3 python3-pip git iproute2 iputils-ping net-tools nano exiftool nmap wget dos2unix smbclient
 RUN git clone https://github.com/dievus/msToolSet-docker.git /opt/msToolSet
 RUN pip3 install -r /opt/msToolSet/requirements.txt


### PR DESCRIPTION
This pull request implements CICD for DockerHub and Github docker repositories by using github actions.
For this to work, once merged, @dievus will need to implement the following github secrets for this repository:

- DOCKER_USERNAME
  - The user name to your dockerhub account
- DOCKER_PASSWORD
  - A token generated for your dockerhub account for CICD
  - https://docs.docker.com/docker-hub/access-tokens/ 
- PAT_TOKEN
  - A personal access token for your github account. Used for publishing the docker image to the github repository
  - https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token

See the following for how to create repository secrets:
- https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
